### PR TITLE
Fix loading of libmatio files

### DIFF
--- a/src/main/java/com/jmatio/io/MatFileReader.java
+++ b/src/main/java/com/jmatio/io/MatFileReader.java
@@ -1110,7 +1110,7 @@ public class MatFileReader
         
         description = zeroEndByteArrayToString(descriptionBuffer);
         
-        if ( !description.matches("MATLAB 5.0 MAT-file.*") )
+        if ( !description.startsWith("MATLAB 5.0 MAT-file") )
         {
             throw new MatlabIOException("This is not a valid MATLAB 5.0 MAT-file.");
         }


### PR DESCRIPTION
The header of mat files written with libmatio includes a trailing newline. The trailing newline is not matched by the regular expression used here. Since the intent seems to be to just check if the headers starts with the specified string, switching this to "startsWith" fixes the problem.